### PR TITLE
fixed build problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+sudo: false
+
 language: node_js
 
 node_js:
-  - "6"
+  - 8
+  - 7
+  - 6
 
 script: npm run lint && npm run build

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
     "url-loader": "^0.5.9",
     "webpack": "^3.5.6",
     "webpack-dev-middleware": "^1.12.0",
-    "webpack-hot-middleware": "^2.19.0"
+    "webpack-hot-middleware": "^2.19.0",
+    "webpack-sources": "1.0.1"
   },
   "dependencies": {
     "apicache": "^0.11.2",


### PR DESCRIPTION
Hi, on building production processing, the babel minify webpack plugin need the dependencies webpack-sources stick to verison 1.0.1. travis work fine [https://travis-ci.org/Gemerz/ieaseMusic](https://travis-ci.org/Gemerz/ieaseMusic)